### PR TITLE
[기능추가] 스프링 시큐리티 설정 적용

### DIFF
--- a/src/main/java/gitfollower/server/config/JwtSecurityConfig.java
+++ b/src/main/java/gitfollower/server/config/JwtSecurityConfig.java
@@ -1,0 +1,22 @@
+package gitfollower.server.config;
+
+import gitfollower.server.jwt.JwtFilter;
+import gitfollower.server.jwt.TokenProvider;
+import org.springframework.security.config.annotation.SecurityConfigurerAdapter;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.web.DefaultSecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+public class JwtSecurityConfig extends SecurityConfigurerAdapter<DefaultSecurityFilterChain, HttpSecurity> {
+    private final TokenProvider tokenProvider;
+
+    public JwtSecurityConfig(TokenProvider tokenProvider) {
+        this.tokenProvider = tokenProvider;
+    }
+
+    @Override
+    public void configure(HttpSecurity http) {
+        JwtFilter customFilter = new JwtFilter(tokenProvider);
+        http.addFilterBefore(customFilter, UsernamePasswordAuthenticationFilter.class);
+    }
+}

--- a/src/main/java/gitfollower/server/config/SecurityConfig.java
+++ b/src/main/java/gitfollower/server/config/SecurityConfig.java
@@ -1,0 +1,59 @@
+package gitfollower.server.config;
+
+import gitfollower.server.jwt.JwtAccessDeniedHandler;
+import gitfollower.server.jwt.JwtAuthenticationEntryPoint;
+import gitfollower.server.jwt.TokenProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+    private final TokenProvider tokenProvider;
+    private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
+    private final JwtAccessDeniedHandler jwtAccessDeniedHandler;
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public AuthenticationManager authenticationManager(AuthenticationConfiguration authenticationConfiguration)
+            throws Exception {
+        return authenticationConfiguration.getAuthenticationManager();
+    }
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+                // "/register" 요청에 대해서만 CSRF 처리 비활성화
+                .csrf((csrf) -> csrf
+                        .ignoringRequestMatchers("/register")
+                )
+                .httpBasic(AbstractHttpConfigurer::disable) // httpBasic.disable()
+                .exceptionHandling(exception -> {
+                    exception.authenticationEntryPoint(jwtAuthenticationEntryPoint);
+                    exception.accessDeniedHandler(jwtAccessDeniedHandler);
+                })
+                .sessionManagement(session -> {
+                    session.sessionCreationPolicy(SessionCreationPolicy.STATELESS);
+                })
+                .authorizeHttpRequests(authorize -> authorize
+                        .requestMatchers( "/register").permitAll()
+                        .anyRequest().authenticated())
+                .apply(new JwtSecurityConfig(tokenProvider));
+        return http.build();
+    }
+}

--- a/src/main/java/gitfollower/server/config/SecurityConfig.java
+++ b/src/main/java/gitfollower/server/config/SecurityConfig.java
@@ -38,10 +38,7 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
-                // "/register" 요청에 대해서만 CSRF 처리 비활성화
-                .csrf((csrf) -> csrf
-                        .ignoringRequestMatchers("/register")
-                )
+                .csrf(AbstractHttpConfigurer::disable) // csrf.disable()
                 .httpBasic(AbstractHttpConfigurer::disable) // httpBasic.disable()
                 .exceptionHandling(exception -> {
                     exception.authenticationEntryPoint(jwtAuthenticationEntryPoint);

--- a/src/main/java/gitfollower/server/jwt/JwtAccessDeniedHandler.java
+++ b/src/main/java/gitfollower/server/jwt/JwtAccessDeniedHandler.java
@@ -1,0 +1,18 @@
+package gitfollower.server.jwt;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+public class JwtAccessDeniedHandler implements AccessDeniedHandler {
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response,
+                       AccessDeniedException accessDeniedException) throws IOException {
+        response.sendError(HttpServletResponse.SC_FORBIDDEN);
+    }
+}

--- a/src/main/java/gitfollower/server/jwt/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/gitfollower/server/jwt/JwtAuthenticationEntryPoint.java
@@ -1,0 +1,18 @@
+package gitfollower.server.jwt;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response,
+                         AuthenticationException authException) throws IOException {
+        response.sendError(HttpServletResponse.SC_UNAUTHORIZED);
+    }
+}

--- a/src/main/java/gitfollower/server/jwt/JwtFilter.java
+++ b/src/main/java/gitfollower/server/jwt/JwtFilter.java
@@ -1,0 +1,68 @@
+package gitfollower.server.jwt;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.GenericFilterBean;
+
+import java.io.IOException;
+
+@Slf4j
+public class JwtFilter extends GenericFilterBean {
+    public static final String AUTHORIZATION_HEADER = "Authorization";
+    private final TokenProvider tokenProvider;
+
+    public JwtFilter(TokenProvider tokenProvider) {
+        this.tokenProvider = tokenProvider;
+    }
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+            throws IOException, ServletException {
+        HttpServletRequest httpServletRequest = (HttpServletRequest) request;
+        String jwt = resolveToken(httpServletRequest);
+        String requestURI = httpServletRequest.getRequestURI();
+
+        if (!isValidJwt(jwt)) {
+            log.info(jwt);
+            log.info("유효한 JWT 토큰 없음, uri = {}", requestURI);
+            chain.doFilter(request, response);
+            return;
+        }
+
+        Authentication authentication = tokenProvider.getAuthentication(jwt);
+        setAuthenticationInSecurityContextHolder(authentication);
+
+        log.info("Security Context에 '{}' 인증 정보 저장, uri = {}", authentication.getName(), requestURI);
+
+        chain.doFilter(request, response);
+    }
+
+    private static void setAuthenticationInSecurityContextHolder(Authentication authentication) {
+        SecurityContext context = SecurityContextHolder.getContext();
+        context.setAuthentication(authentication);
+    }
+
+    private boolean isValidJwt(String jwt) {
+        return StringUtils.hasText(jwt) && tokenProvider.validateToken(jwt);
+    }
+
+    private String resolveToken(HttpServletRequest request) {
+        String bearerToken = request.getHeader(AUTHORIZATION_HEADER);
+        if (isValidBearerToken(bearerToken)) {
+            return bearerToken.substring(7);
+        }
+        return null;
+    }
+
+    private static boolean isValidBearerToken(String bearerToken) {
+        return StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer ");
+    }
+}

--- a/src/main/java/gitfollower/server/jwt/TokenProvider.java
+++ b/src/main/java/gitfollower/server/jwt/TokenProvider.java
@@ -1,0 +1,123 @@
+package gitfollower.server.jwt;
+
+import gitfollower.server.entity.Member;
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.stereotype.Component;
+
+import java.security.Key;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Date;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Component
+public class TokenProvider implements InitializingBean {
+    private static final String AUTHORITIES_KEY = "auth";
+    private final String secret;
+    private final long tokenValidityInMilliseconds;
+    private Key key;
+
+    public TokenProvider(
+            @Value("${jwt.secret}") String secret,
+            @Value("${jwt.token-validity-in-seconds}") long tokenValidityInMilliseconds) {
+        this.secret = secret;
+        this.tokenValidityInMilliseconds = tokenValidityInMilliseconds;
+    }
+
+    @Override
+    public void afterPropertiesSet() throws Exception {
+        byte[] keyBytes = Decoders.BASE64URL.decode(secret);
+        this.key = Keys.hmacShaKeyFor(keyBytes);
+    }
+
+    public String createToken(Authentication authentication, Member member) {
+        String authorities = generateAuthoritiesValue(authentication);
+        long now = checkNowTime();
+        Date validity = generateValidity(now);
+
+        return generateJwt(authentication, member, authorities, validity);
+    }
+
+    private static String generateAuthoritiesValue(Authentication authentication) {
+        return authentication.getAuthorities().stream()
+                .map(GrantedAuthority::getAuthority)
+                .collect(Collectors.joining(","));
+    }
+
+    private static long checkNowTime() {
+        return (new Date()).getTime();
+    }
+
+    private Date generateValidity(long now) {
+        return new Date(now + this.tokenValidityInMilliseconds);
+    }
+
+    private String generateJwt(Authentication authentication, Member member, String authorities, Date validity) {
+        return Jwts.builder()
+                .setSubject(authentication.getName())
+                .claim(AUTHORITIES_KEY, authorities)
+                .claim("member_id", member.getId())
+                .signWith(key, SignatureAlgorithm.HS512)
+                .setExpiration(validity)
+                .compact();
+    }
+
+    public Authentication getAuthentication(String token) {
+        Claims claims = getClaimsInJwt(token);
+
+        Collection<? extends GrantedAuthority> authorities =
+                getAuthoritiesInClaims(claims);
+
+        User principal = getPrincipal(claims, authorities);
+        return new UsernamePasswordAuthenticationToken(principal, token, authorities);
+    }
+
+    private static List<SimpleGrantedAuthority> getAuthoritiesInClaims(Claims claims) {
+        return Arrays.stream(claims.get(AUTHORITIES_KEY).toString().split(","))
+                .map(SimpleGrantedAuthority::new).toList();
+    }
+
+    private static User getPrincipal(Claims claims, Collection<? extends GrantedAuthority> authorities) {
+        return new User(claims.getSubject(), "", authorities);
+    }
+
+    private Claims getClaimsInJwt(String token) {
+        JwtParser parsingJwt = getParsingJwt();
+
+        return parsingJwt.parseClaimsJws(token).getBody();
+    }
+
+    private JwtParser getParsingJwt() {
+        return Jwts.parserBuilder().setSigningKey(key).build();
+    }
+
+    public boolean validateToken(String token) {
+        try {
+            JwtParser parsingJwt = getParsingJwt();
+            parsingJwt.parseClaimsJws(token);
+
+            return true;
+        } catch (SecurityException | MalformedJwtException e) {
+            log.info("잘못된 JWT 서명");
+        } catch (ExpiredJwtException e) {
+            log.info("만료된 JWT 서명");
+        } catch (UnsupportedJwtException e) {
+            log.info("지원되지 않는 JWT 토큰");
+        } catch (IllegalArgumentException e) {
+            log.info("JWT 토큰이 잘못됨");
+        }
+        return false;
+    }
+}


### PR DESCRIPTION
## 작업 내용 👨🏻‍💻
<!-- 작업한 내용을 적고 완료했다면 []안에 x를 넣어주세요! -->
- [x]  SecurityConfig 파일 작성
- [x]  jwt 관련 파일 작성
- [x] Member 엔티티와 연결

## To Reviewers 💬
<!-- 리뷰어(팀원)들이 중점적으로 봐야할 부분, 알고있어야 할 사항들을 적어주세요! -->
- 기본적으로 스프링 시큐리티가 제공하는 `CSRF (Cross Site Reuqest Forgery)` 보호를 비활성화 하였습니다. REST API를 이용하는 경우에는 세션 인증 방식과 다르게 JWT를 활용하기 때문에 서버에 인증 정보를 보관하지 않아 CSRF 취약점에 대해 안전하다고 할 수 있기 때문입니다. (중요한 개념이다보니 추후 위키에 작성하도록 하겠습니다.)
- 기존에 줄곧 사용하던 `SecurityConfig`에서는 `.and()`를 이용한 방식을 사용하였으나, 관련된 에러가 발생함을 파악했습니다.
  <img width="943" alt="스크린샷 2023-08-06 오전 12 41 58" src="https://github.com/GitFollowerBot/GitFollowerServer/assets/90085154/4446250a-3fe3-4df7-b293-bd872facad86">
  - 해당 원인을 분석해 본 결과, 이슈에 미리 작성했듯이 스프링 시큐리티 7.0을 준비함에 따라 람다 방식을 활용할 것을 권장하고 있기 때문임을 파악하였습니다. 관련 글은 [공식 문서](https://docs.spring.io/spring-security/reference/migration-7/configuration.html)에서 아래와 같이 확인할 수 있습니다.
    <img width="538" alt="스크린샷 2023-08-06 오전 12 44 08" src="https://github.com/GitFollowerBot/GitFollowerServer/assets/90085154/c1ebbca7-3cd2-4f8e-8221-77173343e22b">
- `httpBasic(AbstractHttpConfigurer::disable)`은 스프링 시큐리티를 등록했을 때 기본적으로 실행되는 `Http basic Auth` 기반의 로그인 창을 없애기 위함입니다.
- `sessionManagement` 부분에서 `STATELESS`로 하는 이유는 인증 정보를 서버에 담아두지 않도록 하기 위함입니다.
- 서비스 가입 및 실행 로직은 `/register`에서 일어날 것이기에, 해당 url로의 접근은 권한이 없어도 사용할 수 있도록 적용하였습니다.
## Reference 🔬 
<!-- 개발 중 참고한 레퍼런스, 팀원들도 읽어두면 좋은 글이 있다면 링크를 달아주세요! -->
- [Lambda DSL recommend in Spring security official docs](https://docs.spring.io/spring-security/reference/migration-7/configuration.html)
- [Spring boot Security ( api server 기반 )](https://powernote.tistory.com/2)
## Issue 👀
<!-- 관련 이슈를 연결합니다. -->
- #2
- #4 