### PR TITLE
[feat] 회원가입 기능 개발

### DIFF
--- a/src/main/java/gitfollower/server/controller/AuthController.java
+++ b/src/main/java/gitfollower/server/controller/AuthController.java
@@ -1,0 +1,29 @@
+package gitfollower.server.controller;
+
+import gitfollower.server.dto.ApiResponse;
+import gitfollower.server.dto.MemberAddReq;
+import gitfollower.server.exception.ErrorText;
+import gitfollower.server.exception.NicknameDuplicatedException;
+import gitfollower.server.service.AuthService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/")
+@RequiredArgsConstructor
+public class AuthController {
+    private final AuthService authService;
+
+    @PostMapping("/register")
+    public ApiResponse<?> register(@RequestBody MemberAddReq req) {
+        try {
+            return authService.register(req);
+        } catch (NicknameDuplicatedException e) {
+            ErrorText error = ErrorText.NICKNAME_DUPLICATE;
+            return new ApiResponse<>(error.getCode(), error.getBody());
+        }
+    }
+}

--- a/src/main/java/gitfollower/server/dto/ApiResponse.java
+++ b/src/main/java/gitfollower/server/dto/ApiResponse.java
@@ -1,0 +1,17 @@
+package gitfollower.server.dto;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ApiResponse <T> {
+    private int code;
+    private T data;
+
+    public ApiResponse(int code, T data) {
+        this.code = code;
+        this.data = data;
+    }
+}

--- a/src/main/java/gitfollower/server/dto/MemberAddReq.java
+++ b/src/main/java/gitfollower/server/dto/MemberAddReq.java
@@ -1,0 +1,21 @@
+package gitfollower.server.dto;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MemberAddReq {
+    private String nickname;
+    private String token;
+
+    public MemberAddReq withNicknameAndToken(String nickname, String token) {
+        return new MemberAddReq(nickname, token);
+    }
+
+    private MemberAddReq(String nickname, String token) {
+        this.nickname = nickname;
+        this.token = token;
+    }
+}

--- a/src/main/java/gitfollower/server/dto/MemberAddRes.java
+++ b/src/main/java/gitfollower/server/dto/MemberAddRes.java
@@ -1,0 +1,19 @@
+package gitfollower.server.dto;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MemberAddRes {
+    private String nickname;
+
+    public static MemberAddRes withNickname(String nickname) {
+        return new MemberAddRes(nickname);
+    }
+
+    private MemberAddRes(String nickname) {
+        this.nickname = nickname;
+    }
+}

--- a/src/main/java/gitfollower/server/entity/Member.java
+++ b/src/main/java/gitfollower/server/entity/Member.java
@@ -1,5 +1,7 @@
 package gitfollower.server.entity;
 
+import gitfollower.server.dto.MemberAddReq;
+import gitfollower.server.dto.MemberAddRes;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -21,6 +23,10 @@ public class Member {
 
     public static Member withNicknameAndToken(String nickname, String token) {
         return new Member(nickname, token);
+    }
+
+    public static Member from(MemberAddReq req) {
+        return new Member(req.getNickname(), req.getToken());
     }
 
     private Member(String nickname, String token) {

--- a/src/main/java/gitfollower/server/exception/ErrorText.java
+++ b/src/main/java/gitfollower/server/exception/ErrorText.java
@@ -1,0 +1,24 @@
+package gitfollower.server.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorText {
+    NICKNAME_DUPLICATE(400, "NicknameDuplicatedException", "이미 등록되어 있는 유저입니다.");
+
+    private final int code;
+    private final String cause;
+    private final String message;
+
+    public Map<String, String> getBody() {
+        HashMap<String, String> body = new HashMap<>();
+        body.put(getCause(), getMessage());
+
+        return body;
+    }
+}

--- a/src/main/java/gitfollower/server/exception/NicknameDuplicatedException.java
+++ b/src/main/java/gitfollower/server/exception/NicknameDuplicatedException.java
@@ -1,0 +1,12 @@
+package gitfollower.server.exception;
+
+public class NicknameDuplicatedException extends RuntimeException {
+    public static final String message = "이미 등록되어 있는 유저입니다.";
+
+    public NicknameDuplicatedException() {
+    }
+
+    public NicknameDuplicatedException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/gitfollower/server/repository/MemberRepository.java
+++ b/src/main/java/gitfollower/server/repository/MemberRepository.java
@@ -1,0 +1,10 @@
+package gitfollower.server.repository;
+
+import gitfollower.server.entity.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+    Optional<Member> findByNickname(String nickname);
+}

--- a/src/main/java/gitfollower/server/service/AuthService.java
+++ b/src/main/java/gitfollower/server/service/AuthService.java
@@ -19,9 +19,7 @@ public class AuthService {
 
     public ApiResponse<MemberAddRes> register(MemberAddReq req) {
         // 회원 닉네임 검증
-        if (!isUniqueNickname(req.getNickname())) {
-            throw new NicknameDuplicatedException(NicknameDuplicatedException.message);
-        }
+        isUniqueNickname(req);
 
         // 회원을 만들어줘야 함
         Member newMember = Member.from(req);
@@ -33,7 +31,10 @@ public class AuthService {
         return new ApiResponse<>(200, result);
     }
 
-    private boolean isUniqueNickname(String nickname) {
-        return memberRepository.findByNickname(nickname).isEmpty();
+    private void isUniqueNickname(MemberAddReq req) {
+        memberRepository.findByNickname(req.getNickname())
+                .ifPresent(exist -> {
+                    throw new NicknameDuplicatedException(NicknameDuplicatedException.message);
+                });
     }
 }

--- a/src/main/java/gitfollower/server/service/AuthService.java
+++ b/src/main/java/gitfollower/server/service/AuthService.java
@@ -1,0 +1,39 @@
+package gitfollower.server.service;
+
+import gitfollower.server.dto.ApiResponse;
+import gitfollower.server.dto.MemberAddReq;
+import gitfollower.server.dto.MemberAddRes;
+import gitfollower.server.entity.Member;
+import gitfollower.server.exception.NicknameDuplicatedException;
+import gitfollower.server.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class AuthService {
+
+    private final MemberRepository memberRepository;
+
+    public ApiResponse<MemberAddRes> register(MemberAddReq req) {
+        // 회원 닉네임 검증
+        if (!isUniqueNickname(req.getNickname())) {
+            throw new NicknameDuplicatedException(NicknameDuplicatedException.message);
+        }
+
+        // 회원을 만들어줘야 함
+        Member newMember = Member.from(req);
+        memberRepository.save(newMember);
+
+        // 응답 던져주기
+        MemberAddRes result = MemberAddRes.withNickname(newMember.getNickname());
+
+        return new ApiResponse<>(200, result);
+    }
+
+    private boolean isUniqueNickname(String nickname) {
+        return memberRepository.findByNickname(nickname).isEmpty();
+    }
+}


### PR DESCRIPTION
## 작업 내용 👨🏻‍💻
<!-- 작업한 내용을 적고 완료했다면 []안에 x를 넣어주세요! -->
- [x] 기능을 개발하며 필요한 리포지토리 개발
- [x] 기능을 개발하며 필요한 컨트롤러 개발
- [x] 기능을 개발하며 필요한 서비스 개발
- [x] 기능을 개발하며 필요한 DTO 개발
- [x] 조건을 모두 충족할 경우 등록된 닉네임 보여주도록 개발
- [x] 이미 등록된 닉네임인지 검증 
- [x] 예외처리 적용

## To Reviewers 💬
<!-- 리뷰어(팀원)들이 중점적으로 봐야할 부분, 알고있어야 할 사항들을 적어주세요! -->
- `/register`에 `MemberAddReq` DTO 값을 처리하여 회원가입을 하도록 하였습니다.
- 예외 처리는 `RuntimeException`을 상속받은 `NicknameDuplicatedException`을 작성하였고, 해당 예외의 메시지를 주기적으로 활용할 수 있도록 메시지를 `static`으로 두었습니다.
- 예외가 터졌을 때는 `ApiResponse`의 값을 에러 전용으로 담기 위해 `ErrorText`라는 `enum` 타입을 새로 작성하였습니다. `ErrorText`는 `code`, `cause` (발생한 예외), `message` (예외의 메시지)를 담고 있으며, 이를 `HashMap` 형태로 `ApiResponse`에 전달합니다.
- `ApiResponse`도 정적 팩터리 메서드를 적용하려 하였으나, [제네릭 요소를 담고 있기 때문에 정적 팩터리 메서드를 쓸 수 없음](https://vvshinevv.tistory.com/55)을 새로 알았습니다. 필드 값이 단순히 두 개로 한정될 것 같기에 빌더 패턴보다는 생성자 패턴을 사용하기로 하였습니다.
- `MemberAddReq`로부터 `Member`를 만들어내는 로직을 분리한 별도의 정적 팩터리 메서드를 만들었습니다.
- 닉네임이 중복되는지 검증할 때 `Optional`의 특징을 활용하도록 작성하였습니다.
## Reference 🔬 
<!-- 개발 중 참고한 레퍼런스, 팀원들도 읽어두면 좋은 글이 있다면 링크를 달아주세요! -->
- [Spring - Exception 처리 전략 적용기 (+ 에러 코드 문서화!)](https://jaehoney.tistory.com/275)

## Issue 👀
<!-- 관련 이슈를 연결합니다. -->
- #1 
- #7