### PR TITLE
[기능추가] 회원가입 시 깃허브에서의 유효성 검증 적용

### DIFF
--- a/src/main/java/gitfollower/server/controller/AuthController.java
+++ b/src/main/java/gitfollower/server/controller/AuthController.java
@@ -2,8 +2,7 @@ package gitfollower.server.controller;
 
 import gitfollower.server.dto.ApiResponse;
 import gitfollower.server.dto.MemberAddReq;
-import gitfollower.server.exception.ErrorText;
-import gitfollower.server.exception.NicknameDuplicatedException;
+import gitfollower.server.exception.*;
 import gitfollower.server.service.AuthService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -21,8 +20,19 @@ public class AuthController {
     public ApiResponse<?> register(@RequestBody MemberAddReq req) {
         try {
             return authService.register(req);
-        } catch (NicknameDuplicatedException e) {
+        } catch (ConnectionException e) {
+            ErrorText error = ErrorText.CONNECTION_ERROR;
+            return new ApiResponse<>(error.getCode(), error.getBody());
+        }
+        catch (UnvalidGithubNicknameException e) {
+            ErrorText error = ErrorText.UNVALID_GITHUB_USERNAME;
+            return new ApiResponse<>(error.getCode(), error.getBody());
+        }
+        catch (NicknameDuplicatedException e) {
             ErrorText error = ErrorText.NICKNAME_DUPLICATE;
+            return new ApiResponse<>(error.getCode(), error.getBody());
+        } catch (UnAuthorizedGithubToken e) {
+            ErrorText error = ErrorText.UNAUTHORIZED_GITHUB_TOKEN;
             return new ApiResponse<>(error.getCode(), error.getBody());
         }
     }

--- a/src/main/java/gitfollower/server/exception/ConnectionException.java
+++ b/src/main/java/gitfollower/server/exception/ConnectionException.java
@@ -1,0 +1,12 @@
+package gitfollower.server.exception;
+
+public class ConnectionException extends RuntimeException {
+    public static final String message = "연결 오류입니다.";
+
+    public ConnectionException() {
+    }
+
+    public ConnectionException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/gitfollower/server/exception/ErrorText.java
+++ b/src/main/java/gitfollower/server/exception/ErrorText.java
@@ -9,7 +9,10 @@ import java.util.Map;
 @Getter
 @AllArgsConstructor
 public enum ErrorText {
-    NICKNAME_DUPLICATE(400, "NicknameDuplicatedException", "이미 등록되어 있는 유저입니다.");
+    NICKNAME_DUPLICATE(400, "NicknameDuplicatedException", "이미 등록되어 있는 유저입니다."),
+    CONNECTION_ERROR(400, "ConnectionException", "연결 오류입니다."),
+    UNVALID_GITHUB_USERNAME(400, "UnvalidGithubNicknameException", "깃허브에서 찾을 수 없는 닉네임입니다."),
+    UNAUTHORIZED_GITHUB_TOKEN(401, "UnAuthorizedGithubToken", "토큰 주인과 닉네임이 일치하지 않습니다.");
 
     private final int code;
     private final String cause;

--- a/src/main/java/gitfollower/server/exception/UnAuthorizedGithubToken.java
+++ b/src/main/java/gitfollower/server/exception/UnAuthorizedGithubToken.java
@@ -1,0 +1,12 @@
+package gitfollower.server.exception;
+
+public class UnAuthorizedGithubToken extends RuntimeException {
+    public static final String message = "토큰 주인과 닉네임이 일치하지 않습니다.";
+
+    public UnAuthorizedGithubToken() {
+    }
+
+    public UnAuthorizedGithubToken(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/gitfollower/server/exception/UnvalidGithubNicknameException.java
+++ b/src/main/java/gitfollower/server/exception/UnvalidGithubNicknameException.java
@@ -1,0 +1,11 @@
+package gitfollower.server.exception;
+
+public class UnvalidGithubNicknameException extends RuntimeException {
+    public static final String message = "깃허브에서 찾을 수 없는 닉네임입니다.";
+    public UnvalidGithubNicknameException() {
+    }
+
+    public UnvalidGithubNicknameException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/gitfollower/server/github/GithubUrl.java
+++ b/src/main/java/gitfollower/server/github/GithubUrl.java
@@ -1,0 +1,15 @@
+package gitfollower.server.github;
+
+import lombok.Getter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+@Getter
+public class GithubUrl {
+    @Value("${github.prefix}")
+    private String githubPrefix;
+
+    @Value("${github.api-url}")
+    private String githubApiUrl;
+}

--- a/src/main/java/gitfollower/server/service/AuthService.java
+++ b/src/main/java/gitfollower/server/service/AuthService.java
@@ -1,25 +1,39 @@
 package gitfollower.server.service;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import gitfollower.server.dto.ApiResponse;
 import gitfollower.server.dto.MemberAddReq;
 import gitfollower.server.dto.MemberAddRes;
 import gitfollower.server.entity.Member;
+import gitfollower.server.exception.ConnectionException;
 import gitfollower.server.exception.NicknameDuplicatedException;
+import gitfollower.server.exception.UnAuthorizedGithubToken;
+import gitfollower.server.exception.UnvalidGithubNicknameException;
+import gitfollower.server.github.GithubUrl;
 import gitfollower.server.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.*;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.client.RestTemplate;
+
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.URL;
 
 @Service
 @Transactional
 @RequiredArgsConstructor
 public class AuthService {
 
+    private final GithubUrl githubApiUrl;
     private final MemberRepository memberRepository;
 
     public ApiResponse<MemberAddRes> register(MemberAddReq req) {
         // 회원 닉네임 검증
-        isUniqueNickname(req);
+        checkValidGithubUsername(req.getNickname());
+        checkUniqueNickname(req.getNickname());
+        checkTokenOwnerEqualsNickname(req.getToken(), req.getNickname());
 
         // 회원을 만들어줘야 함
         Member newMember = Member.from(req);
@@ -31,10 +45,69 @@ public class AuthService {
         return new ApiResponse<>(200, result);
     }
 
-    private void isUniqueNickname(MemberAddReq req) {
-        memberRepository.findByNickname(req.getNickname())
+
+    private void checkUniqueNickname(String nickname) {
+        memberRepository.findByNickname(nickname)
                 .ifPresent(exist -> {
                     throw new NicknameDuplicatedException(NicknameDuplicatedException.message);
                 });
+    }
+
+    private void checkValidGithubUsername(String username) {
+        try {
+            String urlValue = generateGithubUrl(username);
+            URL githubUrl = new URL(urlValue);
+            HttpURLConnection gitConnection = (HttpURLConnection) githubUrl.openConnection();
+            gitConnection.setRequestMethod("GET");
+
+            int responseCode = gitConnection.getResponseCode();
+            if (!isResponseCodeSuccessful(responseCode))
+                throw new UnvalidGithubNicknameException(UnvalidGithubNicknameException.message);
+
+            gitConnection.disconnect();
+        } catch (IOException e) {
+            throw new ConnectionException(ConnectionException.message);
+        }
+    }
+
+    private static boolean isResponseCodeSuccessful(int responseCode) {
+        return responseCode == 200;
+    }
+
+    private void checkTokenOwnerEqualsNickname(String token, String nickname) {
+        ResponseEntity<JsonNode> response = getResponseInGithubUsingToken(token);
+        JsonNode responseBody = response.getBody();
+        if (responseBody == null || !responseBody.has("login") || !responseBody.get("login").asText().equals(nickname)) {
+            throw new UnAuthorizedGithubToken(UnAuthorizedGithubToken.message);
+        }
+    }
+
+    private ResponseEntity<JsonNode> getResponseInGithubUsingToken(String token) {
+        HttpHeaders headers = createHttpHeaders(token);
+        HttpEntity<?> requestEntity = new HttpEntity<>(headers);
+
+        RestTemplate restTemplate = new RestTemplate();
+        ResponseEntity<JsonNode> response =
+                restTemplate.exchange(githubApiUrl.getGithubApiUrl(), HttpMethod.GET, requestEntity, JsonNode.class);
+        // 이미 깃허브 상에서 닉네임이 존재하는지 여부는 마쳤기 때문에
+        // 이 과정에서 response.getStatusCode가 200이 아니라면 연결 문제라고 설정하였습니다.
+        if (!isRestTemplateConnectionSuccessful(response)) {
+            throw new ConnectionException(ConnectionException.message);
+        }
+        return response;
+    }
+
+    private static HttpHeaders createHttpHeaders(String token) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("Authorization", "Bearer " + token);
+        return headers;
+    }
+
+    private static boolean isRestTemplateConnectionSuccessful(ResponseEntity<JsonNode> response) {
+        return response.getStatusCode() == HttpStatus.OK;
+    }
+
+    private String generateGithubUrl(String username) {
+        return githubApiUrl.getGithubPrefix() + username;
     }
 }


### PR DESCRIPTION
## 작업 내용 👨🏻‍💻
<!-- 작업한 내용을 적고 완료했다면 []안에 x를 넣어주세요! -->
- [x] 닉네임을 입력했을 시, 해당 닉네임이 깃허브에 있는지 검증
- [x] 닉네임과 토큰의 주인이 서로 일치하는지 검증 
- [x] 기존에 작성했던 `isUniqueNickname` 함수 리팩터링

## To Reviewers 💬
<!-- 리뷰어(팀원)들이 중점적으로 봐야할 부분, 알고있어야 할 사항들을 적어주세요! -->
- 깃허브에 해당 닉네임이 있는지 검증하는 것은 `https://github.com/{닉네임}`을 GET 요청했을 시, 200 OK가 나오지 않는다면 존재하지 않는 유저라고 판단하였습니다.
- 토큰의 주인과 닉네임이 일치하는지 검증하는 것은 `RestTemplate`을 활용하였습니다. 깃허브에서는 `https://api.github.com/user`에 GET 요청을 보내면서 `Authorization`에 `Bearer` 토큰으로 자신이 발급한 토큰을 넣었을 때 해당 유저를 식별할 수 있도록 하고 있기 때문에, 이 점을 활용하였습니다. 관련 내용은 [이곳](https://docs.github.com/en/rest/overview/authenticating-to-the-rest-api?apiVersion=2022-11-28)에서 확인하실 수 있습니다.
- `isUniqueNickname` 함수를 리팩터링 하였습니다. is로 시작하는 함수는 `boolean`으로 활용하기로 하였고, 그렇지 않은 `void` 형 함수는 `check`로 시작하도록 하였습니다. 또한, 닉네임을 식별하기만 하면 되기 때문에 인자로 닉네임만 전달하도록 하였습니다. 혹시 만약 이 규칙을 준수하지 않은 메서드들이 추후에 생긴다면 리팩터링하도록 하겠습니다.
- 확실히, 발생할 수 있는 예외들을 다 다루다보니 컨트롤러에서 catch 처리 해야 하는 예외 종류가 많아져 컨트롤러 코드가 지저분해지고 있습니다. 서비스 1차 개발 후 어서 예외처리에 대해 익혀야 할 것 같습니다.

## Reference 🔬 
<!-- 개발 중 참고한 레퍼런스, 팀원들도 읽어두면 좋은 글이 있다면 링크를 달아주세요! -->
* [Authenticating to the REST API - Github Docs](https://docs.github.com/en/rest/overview/authenticating-to-the-rest-api?apiVersion=2022-11-28)
## Issue 👀
<!-- 관련 이슈를 연결합니다. -->
- #7 