### PR TITLE
[feat] 스케줄링 적용하여 주기적으로 팔로워 조회하는 기능 추가

### DIFF
--- a/src/main/java/gitfollower/server/controller/TraceController.java
+++ b/src/main/java/gitfollower/server/controller/TraceController.java
@@ -1,9 +1,12 @@
 package gitfollower.server.controller;
 
 import gitfollower.server.dto.ApiResponse;
+import gitfollower.server.entity.Member;
 import gitfollower.server.exception.ConnectionException;
 import gitfollower.server.exception.ErrorText;
 import gitfollower.server.github.GithubApi;
+import gitfollower.server.service.TraceService;
+import gitfollower.server.util.MemberUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -14,12 +17,14 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class TraceController {
 
-    private final GithubApi githubApi;
+    private final TraceService traceService;
+    private final MemberUtil memberUtil;
 
     @GetMapping("/followers")
     public ApiResponse<?> followers() {
         try {
-            githubApi.getFollowers();
+            Member targetMember = memberUtil.getLoggedInMember();
+            traceService.triggerTracingFollowers(targetMember);
             return null;
         } catch (ConnectionException e) {
             ErrorText error = ErrorText.CONNECTION_ERROR;

--- a/src/main/java/gitfollower/server/service/TraceService.java
+++ b/src/main/java/gitfollower/server/service/TraceService.java
@@ -1,0 +1,52 @@
+package gitfollower.server.service;
+
+import gitfollower.server.entity.Member;
+import gitfollower.server.github.GithubApi;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+import java.util.Collections;
+
+@Service
+@RequiredArgsConstructor
+public class TraceService {
+    private final GithubApi githubApi;
+    private Member member;
+
+    public void triggerTracingFollowers(Member member) {
+        this.member = member;
+        tracingFollowers();
+    }
+
+    @Scheduled(fixedRate = 5000, initialDelay = 3000)
+    public void tracingFollowers() {
+        if (!isExistMember(member))
+            return;
+
+        System.out.println("tracingFollowers 호출"); // 임시 테스트
+
+        SimpleGrantedAuthority simpleGrantedAuthority = new SimpleGrantedAuthority("ROLE_USER");
+        Authentication authentication = new UsernamePasswordAuthenticationToken(member.getNickname(), null,
+                Collections.singleton(simpleGrantedAuthority));
+        setAuthenticationInSecurityContextHolder(authentication);
+
+        githubApi.getFollowers();
+    }
+
+    private static boolean isExistMember(Member member) {
+        return member != null;
+    }
+
+    // JwtFilter에서 썼던 표현 재활용
+    private static void setAuthenticationInSecurityContextHolder(Authentication authentication) {
+        SecurityContext context = SecurityContextHolder.getContext();
+        context.setAuthentication(authentication);
+    }
+}


### PR DESCRIPTION
## 작업 내용 👨🏻‍💻
<!-- 작업한 내용을 적고 완료했다면 []안에 x를 넣어주세요! -->
- [x] 스케줄링과 팔로워 조회를 결합하여 주기적으로 조회하도록 기능 구현

## To Reviewers 💬
<!-- 리뷰어(팀원)들이 중점적으로 봐야할 부분, 알고있어야 할 사항들을 적어주세요! -->
- 추적 기능을 총책임하는 TraceService를 별도로 만들고, 트리거 역할을 하는 `triggerTracingFollowers` 메서드를 만들었습니다.
- triggerTracingFollowers 메서드에서 인자값으로 현재 로그인 된 유저를 넣어줘야, 내부적인 실제 실행 메서드인 `tracingFollowers`에서 인증 정보를 지속적으로 받아올 수 있습니다.
- 인증 정보를 받아오는 코드 (`Authentication` 설정 및 `setAuthenticationInSecurityContextHolder` 메서드)가 중복적임을 파악했습니다. 리팩터링 할 때 한 곳에 저장해둘 수 있도록 고려해보겠습니다.

## Reference 🔬 
<!-- 개발 중 참고한 레퍼런스, 팀원들도 읽어두면 좋은 글이 있다면 링크를 달아주세요! -->

## Issue 👀
<!-- 관련 이슈를 연결합니다. -->
- #13 