### PR TITLE
[기능추가] 새로 팔로우 된 유저 추적 기능 추가

### DIFF
--- a/src/main/java/gitfollower/server/github/GithubApi.java
+++ b/src/main/java/gitfollower/server/github/GithubApi.java
@@ -1,7 +1,9 @@
 package gitfollower.server.github;
 
+import gitfollower.server.entity.Info;
 import gitfollower.server.entity.Member;
 import gitfollower.server.exception.ConnectionException;
+import gitfollower.server.repository.InfoRepository;
 import gitfollower.server.repository.MemberRepository;
 import gitfollower.server.util.MemberUtil;
 import lombok.RequiredArgsConstructor;
@@ -10,9 +12,13 @@ import org.kohsuke.github.GHUser;
 import org.kohsuke.github.GitHub;
 import org.kohsuke.github.GitHubBuilder;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Optional;
 
 @Component
 @RequiredArgsConstructor
@@ -20,6 +26,7 @@ public class GithubApi {
 
     GitHub gitHub;
     private final MemberRepository memberRepository;
+    private final InfoRepository infoRepository;
     private final MemberUtil memberUtil;
 
     private void githubConnection(String token) throws IOException {
@@ -29,20 +36,64 @@ public class GithubApi {
 
     public void getFollowers() {
         try {
+            HashMap<String, ArrayList<String>> result = new HashMap<>();
+            result.put("follow", new ArrayList<>());
+            result.put("unfollow", new ArrayList<>());
+
             Member loggedInMember = memberUtil.getLoggedInMember();
 
             githubConnection(loggedInMember.getToken());
 
             GHUser githubUser = gitHub.getUser(loggedInMember.getNickname());
 
-            /* 임시 테스트 */
-            List<String> followers = githubUser.getFollowers().stream().map(GHPerson::getLogin).toList();
+            addFollowAlert(loggedInMember, githubUser, result);
+            // unFollowAlert(loggedInMember, githubUser, result);
 
-            for (String follower : followers) {
-                System.out.println("follower = " + follower);
-            }
         } catch (IOException e) {
             throw new ConnectionException(ConnectionException.message);
         }
+    }
+
+    private boolean isNotLoggedIn(Member member) {
+        return member == null;
+    }
+
+    @Transactional
+    void addFollowAlert(Member loggedInMember, GHUser githubUser,
+                        HashMap<String, ArrayList<String>> map) throws IOException {
+        List<String> afterFollowers =
+                githubUser.getFollowers().stream().map(GHPerson::getLogin).toList();
+
+        System.out.println("========== [새로 추가된 유저 목록] ==========");
+
+        for (String nickname : afterFollowers) {
+            List<Info> savedFollowerInfo = infoRepository.findAllByOwner(loggedInMember).stream().filter(
+                    x -> x.getFollower().getNickname().equals(nickname)
+            ).toList();
+
+            if (isAlreadyFollow(savedFollowerInfo))
+                continue;
+
+            System.out.println(nickname);
+
+            ArrayList<String> followResultList = map.get("follow");
+            followResultList.add(nickname);
+            map.put("follow", followResultList);
+
+            Member existedMember = memberRepository.findByNickname(nickname).orElseGet(() -> {
+                Member newMember = Member.withNicknameAndToken(nickname, null);
+                memberRepository.save(newMember);
+                return newMember;
+            });
+
+            Info newInfo = Info.withFollowerAndOwner(existedMember, loggedInMember);
+            infoRepository.save(newInfo);
+
+        }
+        System.out.println("=======================================");
+    }
+
+    private static boolean isAlreadyFollow(List<Info> savedFollowerInfo) {
+        return !savedFollowerInfo.isEmpty();
     }
 }

--- a/src/main/java/gitfollower/server/repository/InfoRepository.java
+++ b/src/main/java/gitfollower/server/repository/InfoRepository.java
@@ -1,0 +1,13 @@
+package gitfollower.server.repository;
+
+import gitfollower.server.entity.Info;
+import gitfollower.server.entity.Member;
+import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface InfoRepository extends JpaRepository<Info, Long> {
+    @EntityGraph(attributePaths = "follower")
+    List<Info> findAllByOwner(Member owner);
+}

--- a/src/main/java/gitfollower/server/util/MemberUtil.java
+++ b/src/main/java/gitfollower/server/util/MemberUtil.java
@@ -16,8 +16,14 @@ public class MemberUtil {
 
     public Member getLoggedInMember() {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (isUnAuthorizedAuthentication(authentication))
+            return null;
         String nickname = authentication.getName();
         return memberRepository.findByNickname(nickname)
                 .orElseThrow(() -> new NicknameNotFoundException(NicknameNotFoundException.message));
+    }
+
+    private static boolean isUnAuthorizedAuthentication(Authentication authentication) {
+        return authentication == null;
     }
 }


### PR DESCRIPTION
## 작업 내용 👨🏻‍💻
<!-- 작업한 내용을 적고 완료했다면 []안에 x를 넣어주세요! -->
- [x] 새로 팔로우 된 유저 추적 기능 추가

## To Reviewers 💬
<!-- 리뷰어(팀원)들이 중점적으로 봐야할 부분, 알고있어야 할 사항들을 적어주세요! -->
- 새로 팔로우 된 유저를 추적하는 기능을 개발하였습니다.
- 추적 결과는 임시로 `System.out`으로 찍게 하였습니다.
- 기능을 개발하던 중, `could not initialize proxy - no Session` 이슈를 마주쳤습니다. 해당 오류는 아래 코드를 실행할 때 발생하였습니다.
  ```java
  for (String nickname : afterFollowers) {
      List<Info> savedFollowerInfo = infoRepository.findAllByOwner(loggedInMember).stream).filter(
          × -> x.getFollower().getNickname().equals(nickname) // Info -> Follower 연속 조회 시 문제 발생
      ).toList();
  }
  ```
  - 이 원인은 `지연 로딩에 대한 확실하지 않은 이해` 때문에 발생한 문제였습니다. 지연 로딩으로 받아올 경우 프록시를 받아오게 되는데, 그로 인해 곧바로 Info에서 follower를 받아올 수 없기 때문입니다.
  - 이 문제는 아래 참고 글들을 통해 `@EntityGraph`를 적용하면 해결할 수 있다는 것을 알았으나, `과연 이럼에도 지연 로딩을 써야 할까?` 라는 고민이 들었습니다. 추후 위키에 작성하도록 하겠습니다.
  ```java
  public interface InfoRepository extends JpaRepository<Info, Long> {
      @EntityGraph(attributePaths = "follower") // @EntityGraph 적용
      List<Info> findAllByOwner(Member owner);
  }
  ```

## Reference 🔬 
<!-- 개발 중 참고한 레퍼런스, 팀원들도 읽어두면 좋은 글이 있다면 링크를 달아주세요! -->
- [JPA/ could not initialize proxy - no Session](https://cantcoding.tistory.com/78)
- [@EntityGraph에 대해 알아보자](https://wonin.tistory.com/496)

## Issue 👀
<!-- 관련 이슈를 연결합니다. -->
- #19 