### PR TITLE
[버그수정] Member 중복 생성 시도 문제 해결

### DIFF
--- a/src/main/java/gitfollower/server/github/GithubApi.java
+++ b/src/main/java/gitfollower/server/github/GithubApi.java
@@ -105,17 +105,19 @@ public class GithubApi {
             followResultList.add(nickname);
             map.put("follow", followResultList);
 
-            Member existedMember = memberRepository.findByNickname(nickname).orElseGet(() -> {
-                Member newMember = Member.withNicknameAndToken(nickname, null);
-                memberRepository.save(newMember);
-                return newMember;
-            });
+            Member existedMember = memberRepository.findByNickname(nickname).orElseGet(() -> createMember(nickname));
 
             Info newInfo = Info.withFollowerAndOwner(existedMember, loggedInMember);
             infoRepository.save(newInfo);
         }
 
         System.out.println("=======================================");
+    }
+
+    @Transactional
+    Member createMember(String nickname) {
+        Member newMember = Member.withNicknameAndToken(nickname, null);
+        return memberRepository.save(newMember);
     }
 
     @Transactional


### PR DESCRIPTION
## 작업 내용 👨🏻‍💻
<!-- 작업한 내용을 적고 완료했다면 []안에 x를 넣어주세요! -->
- [x] Member 중복 생성 시도 문제 해결

## To Reviewers 💬
<!-- 리뷰어(팀원)들이 중점적으로 봐야할 부분, 알고있어야 할 사항들을 적어주세요! -->
- 시도했던 방법 1 : 메서드에 `@Lock(LockModeType.PESSIMISTIC_WRITE)` 걸기 - 실패
- 시도했던 방법 2 : 같은 `@Lock`을 `@Scheduled`가 걸린 부분에 걸기 - 실패
- 시도했던 방법 3 : `memberRepository.findByNickname(nickname).orElseGet()` 부분을 별도의 메서드로 빼낸 뒤 해당 메서드에 `@Transactional` 걸기 - 현재까지 문제 없음

## Reference 🔬 
<!-- 개발 중 참고한 레퍼런스, 팀원들도 읽어두면 좋은 글이 있다면 링크를 달아주세요! -->
- ChatGPT를 활용하며 알게 된 케이스이기 때문에 정확한 원인 및 해결 방법 공부가 필요합니다.
- 생각해보면, 삭제 과정에서도 `memberRepository.deleteByFollower`에도 `@Transactional`을 붙였습니다. 같은 원인일 것으로 파악됩니다.

## Issue 👀
<!-- 관련 이슈를 연결합니다. -->
- #30 